### PR TITLE
Ensure that files are loaded before calling function_exported

### DIFF
--- a/src/mg_core_utils.erl
+++ b/src/mg_core_utils.erl
@@ -245,7 +245,7 @@ apply_mod_opts_if_defined(ModOpts, Function, Default) ->
 apply_mod_opts_if_defined(ModOpts, Function, Default, Args) ->
     {Mod, Arg} = separate_mod_opts(ModOpts),
     FunctionArgs = [Arg | Args],
-    ok = maybe_load_file(Mod),
+    ok = maybe_load_module(Mod),
     case erlang:function_exported(Mod, Function, length(FunctionArgs)) of
         true ->
             erlang:apply(Mod, Function, FunctionArgs);
@@ -253,14 +253,14 @@ apply_mod_opts_if_defined(ModOpts, Function, Default, Args) ->
             Default
     end.
 
--spec maybe_load_file(module()) ->
+-spec maybe_load_module(module()) ->
     ok.
-maybe_load_file(Mod) ->
+maybe_load_module(Mod) ->
     case code:ensure_loaded(Mod) of
         {module, Mod} ->
             ok;
         {error, Reason} ->
-            logger:warning("A code loading error occured, reason: ~p", [Reason])
+            logger:warning("An error occured, while loading module ~p, reason: ~p", [Mod, Reason])
     end.
 
 -spec separate_mod_opts(mod_opts()) ->

--- a/src/mg_core_utils.erl
+++ b/src/mg_core_utils.erl
@@ -245,11 +245,22 @@ apply_mod_opts_if_defined(ModOpts, Function, Default) ->
 apply_mod_opts_if_defined(ModOpts, Function, Default, Args) ->
     {Mod, Arg} = separate_mod_opts(ModOpts),
     FunctionArgs = [Arg | Args],
+    ok = maybe_load_file(Mod),
     case erlang:function_exported(Mod, Function, length(FunctionArgs)) of
         true ->
             erlang:apply(Mod, Function, FunctionArgs);
         false ->
             Default
+    end.
+
+-spec maybe_load_file(module()) ->
+    ok.
+maybe_load_file(Mod) ->
+    case code:ensure_loaded(Mod) of
+        {module, Mod} ->
+            ok;
+        {error, Reason} ->
+            logger:warning("A code loading error occured, reason: ~p", [Reason])
     end.
 
 -spec separate_mod_opts(mod_opts()) ->


### PR DESCRIPTION
Во время тестов в `machinegun_woody_api` возникает проблема с тем, что один из модулей не загружается т.к. к нему никогда не обращаются напрямую. Эта проблема проявляется только в interactive режиме код сервера и не должна сказаться на релизной версии приложения, однако необходимость прописывать явную подгрузку в коде тестов очень бесит и хочется заранее пресечь такие ситуации, подгружая модуль в `machinegun`.