### PR TITLE
Do not ignore lost events when reading machine

### DIFF
--- a/src/mg_core_events_machine.erl
+++ b/src/mg_core_events_machine.erl
@@ -665,9 +665,13 @@ storage_event_getter(Options, ID) ->
             mg_core_storage:new_batch(),
             Range
         ),
-        [kv_to_event(ID, {Key, Value}) ||
-            {{get, Key}, {_Context, Value}} <- mg_core_storage:run_batch(StorageOptions, Batch)
-        ]
+        BatchResults = mg_core_storage:run_batch(StorageOptions, Batch),
+        lists:map(
+            fun ({{get, Key}, {_Context, Value}}) ->
+                kv_to_event(ID, {Key, Value})
+            end,
+            BatchResults
+        )
     end.
 
 -spec event_list_getter([mg_core_events:event()]) ->


### PR DESCRIPTION
It's better to fail early than to respond with inconsistent events machine state.