### PR TITLE
Disable sloppy quorum by default

### DIFF
--- a/src/mg_core_storage_riak.erl
+++ b/src/mg_core_storage_riak.erl
@@ -468,8 +468,8 @@ default_option(resolve_timeout) -> 5000;
 default_option(connect_timeout) -> 5000;
 default_option(request_timeout) -> 10000;
 default_option(index_query_timeout) -> 10000;
-default_option(r_options) -> [{r, quorum}, {pr, quorum}];
-default_option(w_options) -> [{w, quorum}, {pw, quorum}, {dw, quorum}];
+default_option(r_options) -> [{r, quorum}, {pr, quorum}, {sloppy_quorum, false}];
+default_option(w_options) -> [{w, quorum}, {pw, quorum}, {dw, quorum}, {sloppy_quorum, false}];
 % ?
 default_option(d_options) -> [].
 


### PR DESCRIPTION
Otherwise it may do more harm then good (especially when coupled with `retry_put_coordinator_failure = true` set in a Riak cluster, which is the default) in the event of _partial_ connectivity loss between cluster nodes.
